### PR TITLE
Support nonetype trivial default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ansible-playbook -i inventory.yml playbook.yml
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|----------|
-| fail2ban_whitelist_ip_ranges | IP ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, set as an empty string. Examples: `''`, `['10.0.0.0/24']` | `list(string)` | n/a | yes |
+| fail2ban_whitelist_ip_ranges | IP ranges (in CIDR format) to be whitelisted in Fail2ban configuration. When in doubt, set as an empty string. Example: `['10.0.0.0/24']` | `list(string)` | `null` | no |
 
 ## Dependencies
 > 💡 Upon execution, a SBOM (SPDX format) is auto-generated and stored in the VM's file system root directory (see `/sbom.json`).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Validate user inputs
   ansible.builtin.assert:
     that:
-      - fail2ban_whitelisted_ip_ranges == '' or (fail2ban_whitelisted_ip_ranges is defined and fail2ban_whitelisted_ip_ranges is iterable and fail2ban_whitelisted_ip_ranges | length > 0)
-      - fail2ban_whitelisted_ip_ranges == '' or (fail2ban_whitelisted_ip_ranges | map('ansible.utils.ipaddr') | list | select | length == fail2ban_whitelisted_ip_ranges | length)
+      - (fail2ban_whitelisted_ip_ranges is none or fail2ban_whitelisted_ip_ranges == '') or (fail2ban_whitelisted_ip_ranges is defined and fail2ban_whitelisted_ip_ranges is iterable and fail2ban_whitelisted_ip_ranges | length > 0)
+      - (fail2ban_whitelisted_ip_ranges is none or fail2ban_whitelisted_ip_ranges == '') or (fail2ban_whitelisted_ip_ranges | map('ansible.utils.ipaddr') | list | select | length == fail2ban_whitelisted_ip_ranges | length)
     fail_msg: "Input validation failed. See README.md for information on required inputs and their format."
     success_msg: "User input configuration is valid."
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Validate user inputs
   ansible.builtin.assert:
     that:
-      - (fail2ban_whitelisted_ip_ranges is none or fail2ban_whitelisted_ip_ranges == '') or (fail2ban_whitelisted_ip_ranges is defined and fail2ban_whitelisted_ip_ranges is iterable and fail2ban_whitelisted_ip_ranges | length > 0)
-      - (fail2ban_whitelisted_ip_ranges is none or fail2ban_whitelisted_ip_ranges == '') or (fail2ban_whitelisted_ip_ranges | map('ansible.utils.ipaddr') | list | select | length == fail2ban_whitelisted_ip_ranges | length)
+      - (fail2ban_whitelisted_ip_ranges is none or fail2ban_whitelisted_ip_ranges == '' or fail2ban_whitelisted_ip_ranges == 'None') or (fail2ban_whitelisted_ip_ranges is defined and fail2ban_whitelisted_ip_ranges is iterable and fail2ban_whitelisted_ip_ranges | length > 0)
+      - (fail2ban_whitelisted_ip_ranges is none or fail2ban_whitelisted_ip_ranges == '' or fail2ban_whitelisted_ip_ranges == 'None') or (fail2ban_whitelisted_ip_ranges | map('ansible.utils.ipaddr') | list | select | length == fail2ban_whitelisted_ip_ranges | length)
     fail_msg: "Input validation failed. See README.md for information on required inputs and their format."
     success_msg: "User input configuration is valid."
 

--- a/templates/ssh.conf.j2
+++ b/templates/ssh.conf.j2
@@ -1,6 +1,6 @@
 [sshd]
 enabled = true
-{% if fail2ban_whitelisted_ip_ranges != '' %}
+{% if fail2ban_whitelisted_ip_ranges != '' and fail2ban_whitelisted_ip_ranges is not none %}
 # Whitelist IP addresses from where incoming traffic is trusted
 ignoreip = {{ fail2ban_whitelisted_ip_ranges | join(' ') }}
 {% endif %}

--- a/templates/ssh.conf.j2
+++ b/templates/ssh.conf.j2
@@ -1,6 +1,7 @@
 [sshd]
 enabled = true
-{% if fail2ban_whitelisted_ip_ranges != '' and fail2ban_whitelisted_ip_ranges is not none %}
+{% if fail2ban_whitelisted_ip_ranges != '' and fail2ban_whitelisted_ip_ranges != 'None' and fail2ban_whitelisted_ip_ranges is not none %}
 # Whitelist IP addresses from where incoming traffic is trusted
 ignoreip = {{ fail2ban_whitelisted_ip_ranges | join(' ') }}
 {% endif %}
+


### PR DESCRIPTION
These changes are introduced to align with the precedence set by CLI tools like `Terraform`/`OpenTofu`, where setting `null` (conceptual equivalent of `None`)  is needed to avoid the complexity of dealing with trivial default values with a complex structure (i.e. dictionaries containing sub dictionaries, lists of dictionaries, etc.)

**IMPORTANT**: The `ansible.builtin.assert` statements used for input validation must continue allowing empty string (`''`) as a synonym of `null`. This is a technical limitation of the `var_prompt` statements we used on Ansible Playbooks that import this Ansible Role. 
To be clear , at the time of writing, when an Ansible Playbook runs  `var_prompt` and asks for an optional input , users have the option to press enter to skip, indicating they want to set the trivial default value. If users do press enter to skip, `var_prompt` set the corresponding variable as a empty `str`, NOT as a `noneType`. Hence the Ansible Role needs to deal with both as if they were equivalent.

Relates to https://github.com/ewcloud/ewc-ansible-role-ssh-bastion/pull/5